### PR TITLE
本番環境のBEとFEのURLの違いによる、cookieの保存と取り出し方法の見直し

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,6 @@ import cors from "cors";
 import * as dotenv from "dotenv";
 import { ResultSetHeader } from "mysql2";
 import mysql2, { Connection, RowDataPacket } from "mysql2/promise";
-import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
 import { LoginController } from "./controllers/login/loginController";
 import { LoginService } from "./services/login/loginService";
@@ -52,10 +51,8 @@ async function main() {
     database: MYSQL_DB as string,
   });
 
-  // ミドルウェア設定: JSONリクエストのパースとクッキーのパース
+  // ミドルウェア設定: JSONリクエストのパース
   app.use(bodyParser.json());
-  app.use(cookieParser());
-
   const loginRepository = new LoginRepository(connection);
   const loginService = new LoginService(loginRepository);
   const loginController = new LoginController(loginService);

--- a/src/controllers/login/loginController.ts
+++ b/src/controllers/login/loginController.ts
@@ -59,6 +59,19 @@ export class LoginController {
         return res.status(500).json({ error: "内部サーバーエラー" });
       }
     });
+
+    // POSTリクエスト(/logout)が来たときの処理
+    this.router.post("/logout", (req: Request, res: Response) => {
+      try {
+        // トークンをクッキーから削除
+        res.clearCookie("token");
+
+        return res.status(200).json({ message: "ログアウトしました。" });
+      } catch (error) {
+        console.error("ログアウト中にエラーが発生しました:", error);
+        return res.status(500).json({ error: "内部サーバーエラー" });
+      }
+    });
   }
 
   public getRouter() {

--- a/src/controllers/login/loginController.ts
+++ b/src/controllers/login/loginController.ts
@@ -45,33 +45,15 @@ export class LoginController {
           return res.status(401).json({ error: "認証に失敗しました。" });
         }
 
-        // トークンをクッキーに設定して返す
-        res.cookie("token", tokenOrError, {
-          maxAge: 30 * 60 * 1000,
-          httpOnly: true,
-          secure: true,
-          sameSite: "strict",
-        });
 
-        return res.status(200).json({ token: tokenOrError });
+
+        return res.status(200).json(tokenOrError);
       } catch (error) {
         console.error("ログイン中にエラーが発生しました:", error);
         return res.status(500).json({ error: "内部サーバーエラー" });
       }
     });
 
-    // POSTリクエスト(/logout)が来たときの処理
-    this.router.post("/logout", (req: Request, res: Response) => {
-      try {
-        // トークンをクッキーから削除
-        res.clearCookie("token");
-
-        return res.status(200).json({ message: "ログアウトしました。" });
-      } catch (error) {
-        console.error("ログアウト中にエラーが発生しました:", error);
-        return res.status(500).json({ error: "内部サーバーエラー" });
-      }
-    });
   }
 
   public getRouter() {

--- a/src/controllers/middlewares/auth.ts
+++ b/src/controllers/middlewares/auth.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { verifyAccessToken } from "../../utils/token";
 
 export function authorization(req: Request, res: Response, next: NextFunction) {
-  const token = req.cookies.token;
+  const token = req.headers.authorization;
   if (token === undefined) {
     return res.status(401).json("None authorization in header");
   }


### PR DESCRIPTION

BEとFEでURLが異なる場合には、BE側でset-cookieが行えない
以下の手順で認証を変更する

BEからのset-cookieを削除
FE側でcookieにトークン保存するように改修
FE側でリクエスト時にcookieから取り出したトークンをheaderに含めるように改修
BE側でheaderからトークンを取り出すように改修